### PR TITLE
fix: parse root dir even if inside a node_modules folder

### DIFF
--- a/src/index.cjs
+++ b/src/index.cjs
@@ -122,7 +122,10 @@ class ScratchWebpackConfigBuilder {
                                 // Some scratch pakcages point to their source (as opposed to a pre-built version)
                                 // for their browser or webpack target. So we need to process them (at the minimum
                                 // to resolve the JSX syntax).
-                                not: [/node_modules[\\/]scratch-(paint|render|svg-renderer|vm)[\\/]src[\\/]/]
+                                not: [
+                                    /node_modules[\\/]scratch-(paint|render|svg-renderer|vm)[\\/]src[\\/]/,
+                                    path.resolve(this._rootPath) // Include the project's root even if in node_modules
+                                ]
                             }
                         ],
                         options: {


### PR DESCRIPTION
### Resolves

**NOTE:** This may not need to be merged in case scratch-android starts using scratch-gui from an npm package, instead of a git commit as it does currently.

A dependency for https://scratchfoundation.atlassian.net/browse/UEPR-139 

### Proposed Changes

Force babel to parse the root folder, even if inside a node_modules futher up the hierarchy.

### Reason for Changes

In another repo - `scratch-android` - we are manually building `scratch-gui` by going inside its folder (which is inside node_modules of `scratch-android`) and making a webpack build. After the update of `scratch-gui` to use `scratch-webpack-config` that stopped working, since currently there is a rule which prevents babel from parsing folders inside a `node_modules` folder. However that is not relative to the the `pwd` so if the project we are trying to build is inside a `node_modules` further up the chain, babel will not transpile the necessary files (e.g. .jsx files). 
