### PR TITLE
feat: allow for css module exceptions

### DIFF
--- a/src/index.cjs
+++ b/src/index.cjs
@@ -39,7 +39,7 @@ class ScratchWebpackConfigBuilder {
      * @param {string|URL} [options.srcPath] The absolute path to the source files. Defaults to `src` under `rootPath`.
      * @param {boolean} [options.shouldSplitChunks] Whether to enable spliting code to chunks.
      */
-    constructor ({ distPath, enableReact, enableTs, libraryName, rootPath, srcPath, publicPath = '/', shouldSplitChunks }) {
+    constructor ({ distPath, enableReact, enableTs, libraryName, rootPath, srcPath, publicPath = '/', shouldSplitChunks, cssModuleExceptions = [] }) {
         const isProduction = process.env.NODE_ENV === 'production';
         const mode = isProduction ? 'production' : 'development';
 
@@ -184,6 +184,7 @@ class ScratchWebpackConfigBuilder {
                         enableReact ? [
                             {
                                 test: /\.css$/,
+                                exclude: cssModuleExceptions,
                                 use: [
                                     {
                                         loader: 'style-loader'
@@ -200,6 +201,25 @@ class ScratchWebpackConfigBuilder {
                                             esModule: false
                                         }
                                     },
+                                    {
+                                        loader: 'postcss-loader',
+                                        options: {
+                                            postcssOptions: {
+                                                plugins: [
+                                                    'postcss-import',
+                                                    'postcss-simple-vars',
+                                                    'autoprefixer'
+                                                ]
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                test: cssModuleExceptions,
+                                use: [
+                                    'style-loader',
+                                    'css-loader',
                                     {
                                         loader: 'postcss-loader',
                                         options: {


### PR DESCRIPTION
### Resolves

https://scratchfoundation.atlassian.net/browse/UEPR-331

### Proposed Changes
Introduce optional cssModuleExceptions property, which does not 

### Reason for Changes

Needed to support library css interactions in scratch-editor
